### PR TITLE
Added parameter to allow timezone configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ When you set up this app, you'll be required to configure five environment varia
  * `GROUPME_GROUP_ID` - The ID for the GroupMe group.  This can be found on the webapp (https://web.groupme.com) under the Settings option for your group.
  * `GROUPME_API_KEY` - A [GroupMe Developer Access Token](https://dev.groupme.com/docs/v3) for a user in the GroupMe group.
  * `CACHE_DURATION` - The duration for which the GroupMe calendar is cached.  `0` will disable caching.
+ * `GROUPME_CALENDAR_TIMEZONE` - Timezone of the calendar events.  See https://en.wikipedia.org/wiki/List_of_tz_database_time_zones for list. Default is `America/Los_Angeles`
  * `GROUPME_STATIC_NAME` - *(Optional)* A static name for the group.  This will lock a name for the calendar, even if the group decides to change their name.
  * `GROUPME_PROXY_URL` - *(Optional)* A proxy URL to provide for the calendar.ics.
 

--- a/app.json
+++ b/app.json
@@ -23,6 +23,10 @@
             "description": "The duration for which the GroupMe calendar is cached, measured in minutes.  `0` will disable caching.",
             "value": "60"
         },
+        "GROUPME_CALENDAR_TIMEZONE": {
+            "description": "Timezone of the calendar events.  See https://en.wikipedia.org/wiki/List_of_tz_database_time_zones for list.",
+            "value": "America/Los_Angeles",
+        },
         "GROUPME_STATIC_NAME": {
             "description": "(Optional) A static name for the group.  This will lock a name for the calendar, even if the group decides to change their name.",
             "value": "",

--- a/app.json
+++ b/app.json
@@ -24,8 +24,8 @@
             "value": "60"
         },
         "GROUPME_CALENDAR_TIMEZONE": {
-            "description": "Timezone of the calendar events.  See https://en.wikipedia.org/wiki/List_of_tz_database_time_zones for list.",
-            "value": "America/Los_Angeles",
+            "description": "Timezone of the calendar events.  See https://en.wikipedia.org/wiki/List_of_tz_database_time_zones for the list of valid timezones.",
+            "value": "America/Los_Angeles"
         },
         "GROUPME_STATIC_NAME": {
             "description": "(Optional) A static name for the group.  This will lock a name for the calendar, even if the group decides to change their name.",

--- a/groupme_cal.py
+++ b/groupme_cal.py
@@ -6,6 +6,7 @@ import utils
 
 app = Flask(__name__)
 with app.app_context():
+    current_app.calendar_timezone = os.environ.get('GROUPME_CALENDAR_TIMEZONE', 'America/Los_Angeles')
     current_app.groupme_calendar_name = 'GroupMe Calendar'
     if os.environ.get('GROUPME_STATIC_NAME', None):
         if os.environ.get('GROUPME_STATIC_NAME', None) != "":
@@ -51,6 +52,7 @@ def index():
         'ics_url_http': ics_url_http,
         'ics_url_webcal': ics_url_webcal,
         'ics_url_google': ics_url_google,
+        'calendar_timezone': current_app.calendar_timezone,
     }
 
     # Return a template, but also some basic info about the latest cache time.

--- a/templates/index.html
+++ b/templates/index.html
@@ -70,7 +70,7 @@
 <div class="container">
     <h1>{{title}} Calendar</h1>
     <div class="row">
-        <div class="col-sm-12" >Subscribe to the calendar for the GroupMe group <a href="https://web.groupme.com/chats/{{groupme_id}}"><b>{{title}}</b></a>:</div>
+        <div class="col-sm-12" >Subscribe to the calendar for the GroupMe group <a href="https://web.groupme.com/chats/{{groupme_id}}"><b>{{title}}</b></a> in timezone {{calendar_timezone}}:</div>
     </div>
     <div class="row calendar-links-row">
         <div class="col-sm-6 calendar-links">

--- a/utils.py
+++ b/utils.py
@@ -66,7 +66,9 @@ def groupme_json_to_ics(groupme_json, static_name=None):
     cal['calscale'] = 'GREGORIAN'
     cal['method'] = 'PUBLISH'
     cal['x-wr-calname'] = 'GroupMe: {}'.format(current_app.groupme_calendar_name)
-    cal['x-wr-timezone'] = 'America/Los_Angeles'
+
+    calendar_timezone = os.environ.get('GROUPME_CALENDAR_TIMEZONE', 'America/Los_Angeles')
+    cal['x-wr-timezone'] = calendar_timezone
 
     for json_blob in groupme_json['response']['events']:
         if 'deleted_at' not in json_blob:

--- a/utils.py
+++ b/utils.py
@@ -66,10 +66,8 @@ def groupme_json_to_ics(groupme_json, static_name=None):
     cal['calscale'] = 'GREGORIAN'
     cal['method'] = 'PUBLISH'
     cal['x-wr-calname'] = 'GroupMe: {}'.format(current_app.groupme_calendar_name)
-
-    calendar_timezone = os.environ.get('GROUPME_CALENDAR_TIMEZONE', 'America/Los_Angeles1')
-    cal['x-wr-timezone'] = calendar_timezone
-
+    cal['x-wr-timezone'] = current_app.calendar_timezone
+    
     for json_blob in groupme_json['response']['events']:
         if 'deleted_at' not in json_blob:
             event = Event()

--- a/utils.py
+++ b/utils.py
@@ -67,7 +67,7 @@ def groupme_json_to_ics(groupme_json, static_name=None):
     cal['method'] = 'PUBLISH'
     cal['x-wr-calname'] = 'GroupMe: {}'.format(current_app.groupme_calendar_name)
 
-    calendar_timezone = os.environ.get('GROUPME_CALENDAR_TIMEZONE', 'America/Los_Angeles')
+    calendar_timezone = os.environ.get('GROUPME_CALENDAR_TIMEZONE', 'America/Los_Angeles1')
     cal['x-wr-timezone'] = calendar_timezone
 
     for json_blob in groupme_json['response']['events']:

--- a/utils.py
+++ b/utils.py
@@ -67,7 +67,7 @@ def groupme_json_to_ics(groupme_json, static_name=None):
     cal['method'] = 'PUBLISH'
     cal['x-wr-calname'] = 'GroupMe: {}'.format(current_app.groupme_calendar_name)
     cal['x-wr-timezone'] = current_app.calendar_timezone
-    
+
     for json_blob in groupme_json['response']['events']:
         if 'deleted_at' not in json_blob:
             event = Event()


### PR DESCRIPTION
Suggested fix to https://github.com/amussey/groupme-calendar-to-ics/issues/5 to remove America/Los_Angeles as hard coded timezone.

FYI, a future suggestion is to replace X-WR-TIMEZONE with VTIMEZONE. See https://blog.jonudell.net/2011/10/17/x-wr-timezone-considered-harmful/